### PR TITLE
Add current step to log output

### DIFF
--- a/lib/src/flash.rs
+++ b/lib/src/flash.rs
@@ -79,7 +79,8 @@ impl Flasher {
     // i hate clones like this but i need self to be mutable due to the zip
     let steps = self.config.steps.clone();
     for step in &steps {
-      tracing::trace!("starting step: {:?}", step);
+      let step_span = tracing::info_span!("step", ?step);
+      let _step_span_enter = step_span.enter();
 
       self.step += 1;
       if let Some(callback) = &self.callback {


### PR DESCRIPTION
If you're using flashthing for the first time, it looks as if it's stuck in a loop and starting over, when it really is just flashing different partitions sequentially.

It would be better to use a tracing span to show the context of the current flashing progress.

Example (will be updated to be more concise before un-marking as draft; ideally would just display the type of step and the filename):

```
2025-04-25T06:30:40.822690Z  INFO flashthing::aml: device found!
2025-04-25T06:30:40.827326Z  INFO flashthing::aml: device connected, claiming interface 0
2025-04-25T06:30:40.827336Z  INFO flashthing::flash: beginning flashing process!
2025-04-25T06:30:40.853701Z  INFO step{step=Bulkcmd { value: "amlmmc key" }}: flashthing::flash: close time.busy=26.3ms time.idle=11.9µs
2025-04-25T06:30:42.454131Z  INFO step{step=WriteLargeMemory { value: WriteLargeMemoryValue { address: 0, data: File(MetaFile { file_path: "boot.bin", encoding: None }), block_length: 4096, append_zeros: None } }}: flashthing::aml: progress: 4.7% | elapsed: 1.6s | eta: 32.8s | rate: 7137.19 KB/s | avg chunk: 1.1s | avg rate: 5119.53 KB/s
2025-04-25T06:30:43.644181Z  INFO step{step=WriteLargeMemory { value: WriteLargeMemoryValue { address: 0, data: File(MetaFile { file_path: "boot.bin", encoding: None }), block_length: 4096, append_zeros: None } }}: flashthing::aml: progress: 9.3% | elapsed: 2.8s | eta: 27.2s | rate: 6885.08 KB/s | avg chunk: 1.2s | avg rate: 5871.95 KB/s
2025-04-25T06:30:44.787950Z  INFO step{step=WriteLargeMemory { value: WriteLargeMemoryValue { address: 0, data: File(MetaFile { file_path: "boot.bin", encoding: None }), block_length: 4096, append_zeros: None } }}: flashthing::aml: progress: 14.0% | elapsed: 3.9s | eta: 24.3s | rate: 7163.25 KB/s | avg chunk: 1.2s | avg rate: 6247.08 KB/s
2025-04-25T06:30:45.904000Z  INFO step{step=WriteLargeMemory { value: WriteLargeMemoryValue { address: 0, data: File(MetaFile { file_path: "boot.bin", encoding: None }), block_length: 4096, append_zeros: None } }}: flashthing::aml: progress: 18.6% | elapsed: 5.1s | eta: 22.1s | rate: 7341.19 KB/s | avg chunk: 1.1s | avg rate: 6488.65 KB/s
2025-04-25T06:30:47.028302Z  INFO step{step=WriteLargeMemory { value: WriteLargeMemoryValue { address: 0, data: File(MetaFile { file_path: "boot.bin", encoding: None }), block_length: 4096, append_zeros: None } }}: flashthing::aml: progress: 23.3% | elapsed: 6.2s | eta: 20.4s | rate: 7287.29 KB/s | avg chunk: 1.1s | avg rate: 6633.90 KB/s
2025-04-25T06:30:48.146170Z  INFO step{step=WriteLargeMemory { value: WriteLargeMemoryValue { address: 0, data: File(MetaFile { file_path: "boot.bin", encoding: None }), block_length: 4096, append_zeros: None } }}: flashthing::aml: progress: 27.9% | elapsed: 7.3s | eta: 18.8s | rate: 7329.42 KB/s | avg chunk: 1.1s | avg rate: 6740.36 KB/s
```