### PR TITLE
Retry bulkcmd on transient failure rather than aborting the flash

### DIFF
--- a/lib/src/aml.rs
+++ b/lib/src/aml.rs
@@ -883,8 +883,36 @@ impl AmlogicSoC {
   ///
   /// # Returns
   /// - `Result<String>`: The command response or an error
+  ///
+  /// Sends the command, retrying on failure. A single send propagates any error to the caller,
+  /// which aborts the flash; this was observed most frequently while validating `dtbo_a`, where
+  /// one failure ended an otherwise-complete flash. `bulkcmd` calls `bulkcmd_once` up to six times
+  /// with a 1500 ms delay between attempts, returning an error only if every attempt fails.
   #[cfg_attr(feature = "instrument", tracing::instrument(level = "trace", skip_all))]
   pub fn bulkcmd(&self, command: &str) -> Result<String> {
+    const BULKCMD_RETRIES: u32 = 6;
+    let mut last_err = None;
+    for attempt in 1..=BULKCMD_RETRIES {
+      match self.bulkcmd_once(command) {
+        Ok(response) => return Ok(response),
+        Err(e) => {
+          tracing::warn!(
+            "bulkcmd {:?} failed (attempt {}/{}): {}; retrying",
+            command,
+            attempt,
+            BULKCMD_RETRIES,
+            e
+          );
+          last_err = Some(e);
+          std::thread::sleep(std::time::Duration::from_millis(1500));
+        }
+      }
+    }
+    Err(last_err.expect("retry loop runs at least once"))
+  }
+
+  /// Send a single bulk command without retrying.
+  fn bulkcmd_once(&self, command: &str) -> Result<String> {
     tracing::debug!("sending bulk command: {:?}", command);
     let mut command = command.as_bytes().to_vec();
     command.push(0x00);


### PR DESCRIPTION
Hi @JoeyEamigh,

First, thank you for all your work and for keeping the Car Thing alive.

I started hacking my Spotify Car Thing(s) over the past couple weeks and I've been posting my progress on the Thing Labs and DeskThing Discords. I'd be happy to connect there and share more about my future plans on how I want to improve DeskThing.

- https://gitlab.com/baiyibai/deskthing-usb-host-mode 
- https://gitlab.com/baiyibai/pico-usb-wifi
- https://gitlab.com/baiyibai/superbird-host-mode (NixOS)

I'm contributing this PR because I experienced multiple failures while attempting to flash my devices. I tried all the advice: expensive cables, thunderbolt cables, cheap cables, hubs, no hubs, powered hubs, different systems, and different USB controllers. I know flash failures are a common problem regardless of the firmware being burned or code being used. For the NixOS flasher, I even dropped the block size down to 512 KB from 2,048 KB and enduring the long flash time. However, after lots of trial and error, I found that a simple retry routine eliminated the problem.


### Summary
This change wraps `bulkcmd` in a retry loop. Currently, each command is sent once and therefore any error propagates to the caller which causes the flash attempt to abort. I observed this behavior most frequently during the validating dtbo_a step, where one failure ended an otherwise-complete flash. The `bulkcmd` command now calls a `bulkcmd_once` function up to six times with a 1500 ms delay between attempts. An error is only returned if every attempt fails. 

Adding retries eliminated the problem and saved me a lot of stress, hopefully others will benefit from this change.